### PR TITLE
Fix enum status case for order updates

### DIFF
--- a/src/main/java/com/example/restaurantapi/entity/MenuOrder.java
+++ b/src/main/java/com/example/restaurantapi/entity/MenuOrder.java
@@ -34,6 +34,6 @@ public class MenuOrder {
     private Status status;
 
     public enum Status {
-        PENDING, COOKING, complete
+        PENDING, COOKING, COMPLETE
     }
 }


### PR DESCRIPTION
## Summary
- use `COMPLETE` enum constant in `MenuOrder` to match case usage

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_b_6841f95d16e4832db4006951d003d795