### PR TITLE
Fix loadtest comment

### DIFF
--- a/loadtest.js
+++ b/loadtest.js
@@ -5,7 +5,7 @@ import { sleep, check } from 'k6';
 export const options = {
   stages: [
     { duration: '10s', target: 100 }, // Tăng lên 10 người dùng trong 10 giây
-    { duration: '20s', target: 200 }, // Duy trì 50 người dùng trong 20 giây
+    { duration: '20s', target: 200 }, // Duy trì 200 người dùng trong 20 giây
     { duration: '10s', target: 0 },  // Giảm về 0 trong 10 giây
   ],
   thresholds: {


### PR DESCRIPTION
## Summary
- update Vietnamese comment in `loadtest.js` to reflect configured target of 200 users

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841fab2c724832d8c5fb7ffbeee3167